### PR TITLE
リクエストのJSONをキャメルの時、スネークにする

### DIFF
--- a/config/initializers/json_param_key_transform.rb
+++ b/config/initializers/json_param_key_transform.rb
@@ -1,0 +1,17 @@
+# File: config/initializers/json_param_key_transform.rb
+# Transform JSON request param keys from JSON-conventional camelCase to
+# Rails-conventional snake_case:
+ActionDispatch::Request.parameter_parsers[:json] = lambda { |raw_post|
+  # Modified from action_dispatch/http/parameters.rb
+  data = ActiveSupport::JSON.decode(raw_post)
+
+  # Transform camelCase param keys to snake_case
+  if data.is_a?(Array)
+    data.map { |item| item.deep_transform_keys!(&:underscore) }
+  else
+    data.deep_transform_keys!(&:underscore)
+  end
+
+  # Return data
+  data.is_a?(Hash) ? data : { '_json': data }
+}


### PR DESCRIPTION
## 詳細
- キャメルケースのJSONでrailsにリクエストする時、自動でスネークケースに直して処理をする。

## 動作確認

![スクリーンショット 2022-09-14 150658](https://user-images.githubusercontent.com/88410576/190073093-ba53799b-c8e1-4562-91ea-6cb45823ddb9.png)
