### PR TITLE
ログインのセッショントークンをフロントのCookieに格納

### DIFF
--- a/app/controllers/api/v1/auth_controller.rb
+++ b/app/controllers/api/v1/auth_controller.rb
@@ -8,7 +8,7 @@ class Api::V1::AuthController < ApplicationController
       cookies.encrypted[:token] = {
         value: user.token,
         secure: true,
-        expires: 3.minute.from_now,
+        expires: 2.weeks.from_now,
         http_only: true
       }
 
@@ -27,7 +27,7 @@ class Api::V1::AuthController < ApplicationController
       cookies.encrypted[:token] = {
         value: user.token,
         secure: true,
-        expires: 3.minute.from_now,
+        expires: 2.weeks.from_now,
         http_only: true
       }
 

--- a/app/controllers/api/v1/auth_controller.rb
+++ b/app/controllers/api/v1/auth_controller.rb
@@ -4,6 +4,14 @@ class Api::V1::AuthController < ApplicationController
     @user = User.new(user_params)
 
     if @user.save
+      encrypted = crypt.encrypt_and_sign(@user.id)
+      cookies[:user_id] = {
+        value: encrypted,
+        secure: true,
+        expires: 1.minute.from_now,
+        http_only: true
+      }
+
       render json: {data: @user, message: "successfully create user"},
       status: 200
     else

--- a/app/controllers/api/v1/auth_controller.rb
+++ b/app/controllers/api/v1/auth_controller.rb
@@ -11,6 +11,11 @@ class Api::V1::AuthController < ApplicationController
         expires: 3.minute.from_now,
         http_only: true
       }
+      cookies[:user_info] = {
+        value: {id: user.id, username: user.username},
+        secure: true,
+        expires: 3.minute.from_now,
+      }
 
       render json: {data: @user, message: "successfully create user"},
       status: 200
@@ -30,6 +35,11 @@ class Api::V1::AuthController < ApplicationController
         expires: 3.minute.from_now,
         http_only: true
       }
+      cookies[:user_info] = {
+        value: {id: user.id, username: user.username},
+        secure: true,
+        expires: 3.minute.from_now,
+      }
 
       render json: {data: user, message: "successfully login"},
       status: 200
@@ -48,8 +58,13 @@ class Api::V1::AuthController < ApplicationController
     cookies.encrypted[:token] = {
       value: nil,
       secure: true,
-      expires: 1.second.from_now,
+      expires: 0.second.from_now,
       http_only: true
+    }
+    cookies[:user_info] = {
+      value: nil,
+      secure: true,
+      expires: 0.second.from_now,
     }
     render json: {message: "successfully logout"},
     status: 200

--- a/app/controllers/api/v1/auth_controller.rb
+++ b/app/controllers/api/v1/auth_controller.rb
@@ -1,14 +1,19 @@
 class Api::V1::AuthController < ApplicationController
 
+
+
+
+  # logout アクションを作る
+
+
   def sign_up
     @user = User.new(user_params)
 
     if @user.save
-      encrypted = crypt.encrypt_and_sign(@user.id)
-      cookies[:user_id] = {
-        value: encrypted,
+      cookies.encrypted[:user_id] = {
+        value: user.id,
         secure: true,
-        expires: 1.minute.from_now,
+        expires: 3.minute.from_now,
         http_only: true
       }
 
@@ -24,11 +29,10 @@ class Api::V1::AuthController < ApplicationController
     user = User.find_by(email: params[:email])
     
     if user&.authenticate(params[:password])
-      encrypted = crypt.encrypt_and_sign(user.id)
-      cookies[:user_id] = {
-        value: encrypted,
+      cookies.encrypted[:user_id] = {
+        value: user.id,
         secure: true,
-        expires: 1.minute.from_now,
+        expires: 3.minute.from_now,
         http_only: true
       }
 
@@ -43,6 +47,10 @@ class Api::V1::AuthController < ApplicationController
         status: 400
       end
     end
+  end
+
+  def logout
+
   end
 
   private

--- a/app/controllers/api/v1/auth_controller.rb
+++ b/app/controllers/api/v1/auth_controller.rb
@@ -1,10 +1,5 @@
 class Api::V1::AuthController < ApplicationController
-
-
-
-
-  # logout アクションを作る
-
+  before_action :authenticate, only: %i[logout]
 
   def sign_up
     @user = User.new(user_params)
@@ -50,7 +45,14 @@ class Api::V1::AuthController < ApplicationController
   end
 
   def logout
-
+    cookies.encrypted[:user_id] = {
+      value: nil,
+      secure: true,
+      expires: 1.second.from_now,
+      http_only: true
+    }
+    render json: {message: "successfully logout"},
+    status: 200
   end
 
   private

--- a/app/controllers/api/v1/auth_controller.rb
+++ b/app/controllers/api/v1/auth_controller.rb
@@ -14,7 +14,16 @@ class Api::V1::AuthController < ApplicationController
 
   def login
     user = User.find_by(email: params[:email])
+    
     if user&.authenticate(params[:password])
+      encrypted = crypt.encrypt_and_sign(user.id)
+      cookies[:user_id] = {
+        value: encrypted,
+        secure: true,
+        expires: 1.minute.from_now,
+        http_only: true
+      }
+
       render json: {data: user, message: "successfully login"},
       status: 200
     else

--- a/app/controllers/api/v1/auth_controller.rb
+++ b/app/controllers/api/v1/auth_controller.rb
@@ -11,11 +11,6 @@ class Api::V1::AuthController < ApplicationController
         expires: 3.minute.from_now,
         http_only: true
       }
-      cookies[:user_info] = {
-        value: {id: user.id, username: user.username},
-        secure: true,
-        expires: 3.minute.from_now,
-      }
 
       render json: {data: @user, message: "successfully create user"},
       status: 200
@@ -34,11 +29,6 @@ class Api::V1::AuthController < ApplicationController
         secure: true,
         expires: 3.minute.from_now,
         http_only: true
-      }
-      cookies[:user_info] = {
-        value: {id: user.id, username: user.username},
-        secure: true,
-        expires: 3.minute.from_now,
       }
 
       render json: {data: user, message: "successfully login"},
@@ -60,11 +50,6 @@ class Api::V1::AuthController < ApplicationController
       secure: true,
       expires: 0.second.from_now,
       http_only: true
-    }
-    cookies[:user_info] = {
-      value: nil,
-      secure: true,
-      expires: 0.second.from_now,
     }
     render json: {message: "successfully logout"},
     status: 200

--- a/app/controllers/api/v1/auth_controller.rb
+++ b/app/controllers/api/v1/auth_controller.rb
@@ -5,8 +5,8 @@ class Api::V1::AuthController < ApplicationController
     @user = User.new(user_params)
 
     if @user.save
-      cookies.encrypted[:user_id] = {
-        value: user.id,
+      cookies.encrypted[:token] = {
+        value: user.token,
         secure: true,
         expires: 3.minute.from_now,
         http_only: true
@@ -24,8 +24,8 @@ class Api::V1::AuthController < ApplicationController
     user = User.find_by(email: params[:email])
     
     if user&.authenticate(params[:password])
-      cookies.encrypted[:user_id] = {
-        value: user.id,
+      cookies.encrypted[:token] = {
+        value: user.token,
         secure: true,
         expires: 3.minute.from_now,
         http_only: true
@@ -45,7 +45,7 @@ class Api::V1::AuthController < ApplicationController
   end
 
   def logout
-    cookies.encrypted[:user_id] = {
+    cookies.encrypted[:token] = {
       value: nil,
       secure: true,
       expires: 1.second.from_now,

--- a/app/controllers/api/v1/posts_controller.rb
+++ b/app/controllers/api/v1/posts_controller.rb
@@ -5,12 +5,6 @@ class Api::V1::PostsController < ApplicationController
   def index
     @posts = Post.where(published: true).order(created_at: :desc)
 
-    if current_user.present?
-      render json: {data: current_user, message: "successfully get posts"},
-        status: 200
-      return
-    end
-
     render json: {data: @posts, message: "successfully get posts"},
       status: 200
   end
@@ -28,22 +22,7 @@ class Api::V1::PostsController < ApplicationController
   def create
     @post = Post.new(post_params)
     meta = MetaInspector.new(@post.url)
-
-    encrypted = crypt.encrypt_and_sign('Qiitaきーたキータ')
     
-    # secure: true じゃないと、セット出来ない
-    cookies[:abc] = {
-      value: encrypted,
-      secure: true,
-      http_only: true
-    }
-    cookies[:http_only] = {
-      value: 2,
-      # expires: "2022-10-1".to_date,
-      secure: true,
-      http_only: true
-    }
-
     # meta情報も追加する
     if @post.save && meta.present?
       title = meta.title || ""

--- a/app/controllers/api/v1/posts_controller.rb
+++ b/app/controllers/api/v1/posts_controller.rb
@@ -4,6 +4,20 @@ class Api::V1::PostsController < ApplicationController
 
   def index
     @posts = Post.where(published: true).order(created_at: :desc)
+    cookies[:jijijjijijijijijijijijiij] = 1
+    cookies.signed[:s] = "aa"
+    # cookies.encrypted[:angou] = 1
+    cookies[:angou] = {
+      value: 20,
+      expires: "2022-10-1".to_date,
+      secure: true,
+      httponly: true,
+      http_only: true
+    }
+    if cookies[:angou].present?
+      render json: {data:cookies[:angou]}
+      return
+    end
     render json: {data: @posts, message: "successfully get posts"},
       status: 200
   end

--- a/app/controllers/api/v1/posts_controller.rb
+++ b/app/controllers/api/v1/posts_controller.rb
@@ -4,22 +4,50 @@ class Api::V1::PostsController < ApplicationController
 
   def index
     @posts = Post.where(published: true).order(created_at: :desc)
-    cookies[:jijijjijijijijijijijijiij] = 1
-    cookies.signed[:s] = "aa"
-    # cookies.encrypted[:angou] = 1
-    cookies[:angou] = {
-      value: 20,
-      expires: "2022-10-1".to_date,
-      secure: true,
-      httponly: true,
-      http_only: true
-    }
-    if cookies[:angou].present?
-      render json: {data:cookies[:angou]}
+
+    if cookies[:http_only].nil?
+      render json: {data: "no", message: "successfully get posts"},
+        status: 200
       return
     end
-    render json: {data: @posts, message: "successfully get posts"},
+    
+    # ブラウザのCookieに入っていても、nullに
+  #   render json: {data: cookies[:http_only], message: "successfully get posts"},
+  #   status: 200
+  # return
+
+    # cookies[:normal] = 1
+    # cookies.signed[:signed] = "aa" # 署名付き 暗号化、改ざん不可
+    # cookies.encrypted[:angou] = 1 # 暗号化、改ざん・読み込み不可
+
+    # cookies[:http_only] = {
+    #   value: 2,
+    #   # expires: "2022-10-1".to_date,
+    #   secure: true,
+    #   http_only: true
+    # }
+    user = User.find(cookies[:http_only])
+    posts = user.posts.order(created_at: :desc)
+    posts = posts.where(published: true) if @user != current_user
+
+
+    render json: {data: posts, message: "successfully get posts"},
       status: 200
+    return
+    # if session[:user_name].present?
+    #   render json:{ data:session[:user_name]}
+    #   return
+    # else
+    #   session[:user_name] = "test!!"
+    # end
+    # if cookies[:signed].present?
+    #   render json: {data:cookies.signed[:signed]}
+    #   return
+    # end
+    # render json: {data: @posts, message: "successfully get posts"},
+    #   status: 200
+      render json: {data: @posts, message: "successfully get posts"},
+        status: 200
   end
 
   def show
@@ -35,6 +63,18 @@ class Api::V1::PostsController < ApplicationController
   def create
     @post = Post.new(post_params)
     meta = MetaInspector.new(@post.url)
+    
+    # secure: true じゃないと、セット出来ない
+    # cookies[:normal] = 1
+    # cookies.signed[:signed] = "aa" # 署名付き 暗号化、改ざん不可
+    # cookies.encrypted[:angou] = 1 # 暗号化、改ざん・読み込み不可
+
+    cookies[:http_only] = {
+      value: 2,
+      # expires: "2022-10-1".to_date,
+      secure: true,
+      http_only: true
+    }
 
     # meta情報も追加する
     if @post.save && meta.present?

--- a/app/controllers/api/v1/posts_controller.rb
+++ b/app/controllers/api/v1/posts_controller.rb
@@ -5,49 +5,14 @@ class Api::V1::PostsController < ApplicationController
   def index
     @posts = Post.where(published: true).order(created_at: :desc)
 
-    if cookies[:http_only].nil?
-      render json: {data: "no", message: "successfully get posts"},
+    if current_user.present?
+      render json: {data: current_user, message: "successfully get posts"},
         status: 200
       return
     end
-    
-    # ブラウザのCookieに入っていても、nullに
-  #   render json: {data: cookies[:http_only], message: "successfully get posts"},
-  #   status: 200
-  # return
 
-    # cookies[:normal] = 1
-    # cookies.signed[:signed] = "aa" # 署名付き 暗号化、改ざん不可
-    # cookies.encrypted[:angou] = 1 # 暗号化、改ざん・読み込み不可
-
-    # cookies[:http_only] = {
-    #   value: 2,
-    #   # expires: "2022-10-1".to_date,
-    #   secure: true,
-    #   http_only: true
-    # }
-    user = User.find(cookies[:http_only])
-    posts = user.posts.order(created_at: :desc)
-    posts = posts.where(published: true) if @user != current_user
-
-
-    render json: {data: posts, message: "successfully get posts"},
+    render json: {data: @posts, message: "successfully get posts"},
       status: 200
-    return
-    # if session[:user_name].present?
-    #   render json:{ data:session[:user_name]}
-    #   return
-    # else
-    #   session[:user_name] = "test!!"
-    # end
-    # if cookies[:signed].present?
-    #   render json: {data:cookies.signed[:signed]}
-    #   return
-    # end
-    # render json: {data: @posts, message: "successfully get posts"},
-    #   status: 200
-      render json: {data: @posts, message: "successfully get posts"},
-        status: 200
   end
 
   def show
@@ -63,12 +28,15 @@ class Api::V1::PostsController < ApplicationController
   def create
     @post = Post.new(post_params)
     meta = MetaInspector.new(@post.url)
+
+    encrypted = crypt.encrypt_and_sign('Qiitaきーたキータ')
     
     # secure: true じゃないと、セット出来ない
-    # cookies[:normal] = 1
-    # cookies.signed[:signed] = "aa" # 署名付き 暗号化、改ざん不可
-    # cookies.encrypted[:angou] = 1 # 暗号化、改ざん・読み込み不可
-
+    cookies[:abc] = {
+      value: encrypted,
+      secure: true,
+      http_only: true
+    }
     cookies[:http_only] = {
       value: 2,
       # expires: "2022-10-1".to_date,

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::UsersController < ApplicationController
   before_action :set_user, only: %i[show]
-  before_action :authenticate
+  before_action :authenticate, only: %i[index update delete me]
 
   # ユーザー一覧を表示 (名前だけでいい)
   def index
@@ -37,6 +37,7 @@ class Api::V1::UsersController < ApplicationController
 
   # users/ DELETE
   # usernameを「退会済みユーザー」にする
+  # destroyに変更
   def delete
     if current_user.destroy
       render json: {data: current_user, message: "successfully delete user"},

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,9 +5,14 @@ class ApplicationController < ActionController::API
   
   protected
     def current_user
-      authenticate_with_http_token do |token, options|
-        auth_user = User.find_by(token: token)
+      # authenticate_with_http_token do |token, options|
+      #   auth_user = User.find_by(token: token)
+      # end
+      if cookies[:user_id].nil?
+        return
       end
+      user_id = crypt.decrypt_and_verify(cookies[:user_id])
+      user = User.find(user_id)
     end
     
     def authenticate
@@ -17,5 +22,11 @@ class ApplicationController < ActionController::API
     def render_unauthorized
       render json: {message: "token invalid"},
       status: 401
+    end
+
+    def crypt
+      key_len = ActiveSupport::MessageEncryptor.key_len
+      secret = Rails.application.key_generator.generate_key('salt', key_len)
+      ActiveSupport::MessageEncryptor.new(secret)
     end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -19,11 +19,6 @@ class ApplicationController < ActionController::API
           expires: 0.second.from_now,
           http_only: true
         }
-        cookies[:user_info] = {
-          value: nil,
-          secure: true,
-          expires: 0.second.from_now,
-        }
         return
       end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,7 +11,20 @@ class ApplicationController < ActionController::API
       if cookies[:user_id].nil?
         return
       end
-      user_id = crypt.decrypt_and_verify(cookies[:user_id])
+      # user_id = crypt.decrypt_and_verify(cookies[:user_id])
+      begin
+        user_id = crypt.decrypt_and_verify(cookies[:user_id])
+      rescue
+        # cookies.delete(:user_id)
+        cookies[:user_id] = {
+          value: nil,
+          secure: true,
+          expires: 1.second.from_now,
+          http_only: true
+        }
+        return
+      end
+
       user = User.find(user_id)
     end
     
@@ -20,6 +33,7 @@ class ApplicationController < ActionController::API
     end
 
     def render_unauthorized
+      cookies.delete(:user_id) if cookies[:user_id].present?
       render json: {message: "token invalid"},
       status: 401
     end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,15 +5,15 @@ class ApplicationController < ActionController::API
   
   protected
     def current_user
-      if cookies[:user_id].nil?
+      if cookies[:token].nil?
         return
       end
 
-      user_id = cookies.encrypted[:user_id]
+      token = cookies.encrypted[:token]
 
       # デコード失敗したらcookieを消す
-      if user_id.nil?
-        cookies.encrypted[:user_id] = {
+      if token.nil?
+        cookies.encrypted[:token] = {
           value: nil,
           secure: true,
           expires: 1.second.from_now,
@@ -22,7 +22,7 @@ class ApplicationController < ActionController::API
         return
       end
 
-      User.find(user_id)
+      User.find_by(token: token)
     end
     
     def authenticate

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,8 +16,13 @@ class ApplicationController < ActionController::API
         cookies.encrypted[:token] = {
           value: nil,
           secure: true,
-          expires: 1.second.from_now,
+          expires: 0.second.from_now,
           http_only: true
+        }
+        cookies[:user_info] = {
+          value: nil,
+          secure: true,
+          expires: 0.second.from_now,
         }
         return
       end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 class ApplicationController < ActionController::API
   include ActionController::HttpAuthentication::Token::ControllerMethods
   include ActionController::HttpAuthentication::Basic::ControllerMethods
+  include ActionController::Cookies
   
   protected
     def current_user

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,8 +11,14 @@ module SharePosApi
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.0
     # Configuration for the application, engines, and railties goes here.
+    
+    # フロントのCookieをいじる設定
     config.middleware.use ActionDispatch::Cookies
+    # フロントのCookieのSameSite属性をNoneに設定
+    config.action_dispatch.cookies_same_site_protection = :none 
+    # フロントのSessionをいじる設定
     config.middleware.use ActionDispatch::Session::CookieStore
+
     # These settings can be overridden in specific environments using the files
     # in config/environments, which are processed later.
     #

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,9 +10,9 @@ module SharePosApi
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.0
-
     # Configuration for the application, engines, and railties goes here.
-    #
+    config.middleware.use ActionDispatch::Cookies
+    config.middleware.use ActionDispatch::Session::CookieStore
     # These settings can be overridden in specific environments using the files
     # in config/environments, which are processed later.
     #
@@ -22,6 +22,7 @@ module SharePosApi
     # Only loads a smaller set of middleware suitable for API only apps.
     # Middleware like session, flash, cookies can be added back manually.
     # Skip views, helpers and assets when generating a new resource.
-    config.api_only = true
+    config.api_only = false
+    # config.api_only = true
   end
 end

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -7,11 +7,14 @@
 
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
+    # このURLからのアクセスを許可する
     origins ["http://localhost:3000","https://share-pos.vercel.app" ]
 
+    # resource: 許可するcontrollder (api/v1/*)とか
     resource "*",
       headers: :any,
       :expose => ['access-token', 'expiry', 'token-type', 'uid', 'client'],
-      methods: [:get, :post, :put, :patch, :delete, :options, :head]
+      methods: [:get, :post, :put, :patch, :delete, :options, :head],
+      credentials: true # フロントのCookieいじる設定
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
       resources :auth, only: %i[] do
         collection do
           post :login
+          delete :logout
           post :sign_up
         end
       end


### PR DESCRIPTION
## 詳細
以前は、ログインに成功時にフロントがトークンを取得して、Cookieに格納して、認証が必要なAPIを叩く時にheaderにトークンを格納していた

今回の実装では、ログインに成功時にバックエンドが、フロントのCookieに暗号化したトークンを格納する。そして、認証が必要な時にフロントのCookieを取得して認証するように変更した。

- ログインに成功時、フロントのCookieに、JavaScriptでアクセス出来ない、暗号化されたtokenを格納
- フロントのCookieにアクセスするための設定追加
- current_user を、フロントのCookieにtokenがあるかで判断し、そのtokenからUserを返す。
- Cookieのtokenが不正に変えられた時、Cookieのtokenを自動で削除する。
- logoutアクションの追加

## 動作確認