### PR TITLE
#63 フォロー機能

### DIFF
--- a/app/controllers/api/v1/user_relations_controller.rb
+++ b/app/controllers/api/v1/user_relations_controller.rb
@@ -1,0 +1,68 @@
+class Api::V1::UserRelationsController < ApplicationController
+  before_action :set_followed_user
+  # before_action :authenticate
+
+  # フォローする
+  def create
+    # 既にフォローしている場合
+    if current_user.following?(@followed_user)
+      render json: {message: "既にユーザーをフォローしています"},
+        status: 400
+      return
+    end
+
+    if current_user.follow(@followed_user.id)
+      @user = {id: @followed_user.id, username: @followed_user.username}
+      render json: {data: @user, message: "successfully follow"},
+        status: 200
+    else
+      render json: {message: "フォローに失敗しました"},
+        status: 400
+    end
+  end
+
+  # フォロー解除
+  def destroy
+    # まだフォローしていない
+    if !current_user.following?(@followed_user)
+      render json: {message: "このユーザーをフォローしていません"},
+        status: 400
+      return
+    end
+
+    if current_user.unfollow(@followed_user.id)
+      @user = {id: @followed_user.id, username: @followed_user.username}
+      render json: {data: @user, message: "successfully unfollow"},
+        status: 200
+    else
+      render json: {message: "フォロー解除に失敗しました"},
+        status: 400
+    end
+  end
+
+  # フォロウィング一覧
+  def followings
+    render json: {data: @followed_user.followings, message: "successfully get followings"},
+      status: 200
+  end
+
+  # フォロワー一覧
+  def followers
+    render json: {data: @followed_user.followers, message: "successfully get followers"},
+      status: 200
+  end
+
+  private
+
+  def set_followed_user
+    # parmasのuserが存在しない
+    if !User.exists?(params[:user_id])
+      render json: {message: "ユーザーが存在しません"},
+        status: 404
+      return
+    end
+
+    @followed_user = User.find(params[:user_id])
+  end
+  
+end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -15,13 +15,22 @@ class Api::V1::UsersController < ApplicationController
       status: 200
   end
 
-  # 今後フォロー機能や、他のユーザーの投稿を個別で見る時に使う
   def show
     posts = @user.posts.order(created_at: :desc)
     posts = posts.where(published: true) if @user != current_user
 
-    render json: {data: {user: {id:@user.id ,username: @user.username}, posts: posts}, message: "successfully get user"},
-      status: 200
+    # フォローしているか、フォロワー数、フォロー数も返す
+    user_info = {id:@user.id ,username: @user.username}
+    is_followed = current_user.present? ? current_user.following?(@user) : false
+    render json: {data: {
+        user: user_info,
+        posts: posts,
+        is_followed: is_followed,
+        following_count: @user.followings.count,
+        follower_count: @user.followers.count
+      },
+      message: "successfully get user"},
+    status: 200
   end
 
   # users/ PUT

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,4 +12,42 @@ class User < ActiveRecord::Base
 
   has_many :posts # delete_allはいらない
   has_many :folders, dependent: :delete_all
+
+  # フォローをする関係
+  has_many :active_relationships,       # 今つけた名前
+  class_name: "UserRelation", # テーブルを参照
+  foreign_key: "follower_id", # このカラムを使う
+  dependent: :destroy         # ユーザー消したら関連も消えるよ
+
+  # フォロワーの関係
+  has_many :passive_relationships,      # 今つけた名前
+      class_name: "UserRelation", # テーブルを参照
+      foreign_key: "followed_id", # このカラムを使う
+      dependent: :destroy         # ユーザー消したら関連も消えるよ
+
+
+  # 一覧画面で使用できるようにする user.followers で使える
+  has_many :followings,
+      through: :active_relationships,
+      source: :followed # followingsはfollowed idの集合体
+
+  has_many :followers,
+      through: :passive_relationships,
+      source: :follower  # followingsはfollower idの集合体
+
+      
+  # フォローする
+  def follow(user_id)
+    active_relationships.create(followed_id: user_id)
+  end
+
+  # フォロー解除
+  def unfollow(user_id)
+    active_relationships.find_by(followed_id: user_id).destroy
+  end
+
+  # 現在のユーザーがフォローしてるか
+  def following?(user)
+    followings.include?(user)
+  end
 end

--- a/app/models/user_relation.rb
+++ b/app/models/user_relation.rb
@@ -1,0 +1,5 @@
+class UserRelation < ApplicationRecord
+  # User同士のリレーションだから、特殊 class_nameで、そのテーブルから参照してる
+  belongs_to :follower, class_name: "User"
+  belongs_to :followed, class_name: "User"
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,11 +12,17 @@ Rails.application.routes.draw do
           post :sign_up
         end
       end
+
       resources :users, only: %i[index show] do
         collection do
           get :me
         end
+        post "follow", to: "user_relations#create"
+        delete "follow", to: "user_relations#destroy"
+        get "followings", to: "user_relations#followings"
+        get "followers", to: "user_relations#followers"
       end
+
       put "users", to: "users#update" # idを受け取らない
       patch "users", to: "users#update"
       delete "users", to: "users#destroy"
@@ -26,14 +32,17 @@ Rails.application.routes.draw do
           delete :destroy_all
         end
       end
+
       resources :folders do
         collection do
           post "bookmarks", to: "folder_post_relations#create"
           delete "bookmarks/:id", to: "folder_post_relations#destroy"
         end
       end
+
       resources :metas, only: %i[index]
       resources :reply_comments, only: %i[create update destroy]
+      
     end
 end
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html

--- a/db/migrate/20230202013254_create_user_relations.rb
+++ b/db/migrate/20230202013254_create_user_relations.rb
@@ -1,0 +1,10 @@
+class CreateUserRelations < ActiveRecord::Migration[7.0]
+  def change
+    create_table :user_relations do |t|
+      t.integer :follower_id
+      t.integer :followed_id
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_11_18_065526) do
-  # これいらない
+ActiveRecord::Schema[7.0].define(version: 2023_02_02_013254) do
   create_table "comments", force: :cascade do |t|
     t.integer "post_id", null: false
     t.integer "user_id", null: false
@@ -67,6 +66,13 @@ ActiveRecord::Schema[7.0].define(version: 2022_11_18_065526) do
     t.datetime "updated_at", null: false
     t.index ["post_id"], name: "index_reply_comments_on_post_id"
     t.index ["user_id"], name: "index_reply_comments_on_user_id"
+  end
+
+  create_table "user_relations", force: :cascade do |t|
+    t.integer "follower_id"
+    t.integer "followed_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "users", force: :cascade do |t|

--- a/test/controllers/user_relations_controller_test.rb
+++ b/test/controllers/user_relations_controller_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class UserRelationsControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get user_relations_index_url
+    assert_response :success
+  end
+end

--- a/test/fixtures/user_relations.yml
+++ b/test/fixtures/user_relations.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  follower_id: 1
+  followed_id: 1
+
+two:
+  follower_id: 1
+  followed_id: 1

--- a/test/models/user_relation_test.rb
+++ b/test/models/user_relation_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class UserRelationTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 関連issue
- #63 
## 詳細

- Userのリレーションテーブル作成
  - followed_id, follower_id
- Userレコードにメソッドを生やす
  - follow(id) 
    - idのユーザーをフォローする
  - unfollow(id)
    - idのユーザーをアンフォローする
  - following?(user)
    - userをフォローしてればtrue
  - followings
    - フォローしているユーザー一覧
  - followers
    - フォロワー一覧

## エンドポイント

フォローする
  - POST :　/users/[:followed_id]/follow
    - 自分(following_id)はcurrent_userから
  - res: {data: {user: {id: 1, username: "test"}}, message: ""}

フォロー解除
  - DELETE :　/users/[:followed_id]/follow
  - 自分(following_id)はcurrent_userから

ユーザー毎の、フォローしているユーザー一覧
  - GET :　/users/[:user_id]/followings

ユーザー毎の、フォローされているユーザー一覧
  - GET :　/users/[:user_id]/followers

レスポンスに、フォロー人数、フォロワー人数も追加する
- GET :　/user/[:user_id]
- body: { follower_count, following_count }

自分以外のユーザーを返すとき、email, password_digest, tokenは返さないように